### PR TITLE
change JitterTypes from enum to union

### DIFF
--- a/src/jitter/jitter.factory.ts
+++ b/src/jitter/jitter.factory.ts
@@ -1,4 +1,4 @@
-import { IBackOffOptions, JitterTypes } from "../options";
+import { IBackOffOptions } from "../options";
 import { fullJitter } from "./full/full.jitter";
 import { noJitter } from "./no/no.jitter";
 
@@ -6,10 +6,10 @@ export type Jitter = (delay: number) => number;
 
 export function JitterFactory(options: IBackOffOptions): Jitter {
     switch (options.jitter) {
-        case JitterTypes.Full:
+        case "full":
             return fullJitter
         
-        case JitterTypes.None:
+        case "none":
         default:
             return noJitter
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,11 +1,8 @@
-export enum JitterTypes {
-  None = "none",
-  Full = "full"
-}
+export type JitterType = "none" | "full";
 
 export interface IBackOffOptions {
   delayFirstAttempt: boolean;
-  jitter: JitterTypes;
+  jitter: JitterType;
   maxDelay: number;
   numOfAttempts: number;
   retry: (e: any, attemptNumber: number) => boolean;
@@ -15,7 +12,7 @@ export interface IBackOffOptions {
 
 const defaultOptions: IBackOffOptions = {
   delayFirstAttempt: false,
-  jitter: JitterTypes.None,
+  jitter: "none",
   maxDelay: Infinity,
   numOfAttempts: 10,
   retry: () => true,


### PR DESCRIPTION
Hi! First of all great work on your lib!

I was trying to use it but found a problem when trying to define the jitter type because the `JitterTypes` enum is not exported from `backoff.ts`. Looking through the code I thought that making `JitterTypes` a union instead of enum improved usability.

Let me know what you think! If you opt for this approach I believe this would be a major release since some people might be importing the JitterTypes directly from dist folder and it would break their builds.

