### PR TITLE
adjust README to reflect optional options; export new interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ npm i exponential-backoff
 
 ## Usage
 
-The `backOff<T>` function takes a promise-returning function to retry, and an optional `IBackOffOptions` object. It returns a `Promise<T>`.
+The `backOff<T>` function takes a promise-returning function to retry, and an optional `BackOffOptions` object. It returns a `Promise<T>`.
 
 ```ts
 function backOff<T>(
   request: () => Promise<T>,
-  options?: IBackOffOptions
+  options?: BackOffOptions
 ): Promise<T>;
 ```
 
@@ -42,7 +42,7 @@ main();
 
 Migrating across major versions? Here are our [breaking changes](https://github.com/coveo/exponential-backoff/tree/master/doc/migration-guide.md).
 
-### `IBackOffOptions`
+### `BackOffOptions`
 
 - `delayFirstAttempt?: boolean`
 

--- a/src/backoff.spec.ts
+++ b/src/backoff.spec.ts
@@ -1,11 +1,11 @@
 import { backOff } from "./backoff";
-import { IBackOffOptions } from "./options";
+import { BackoffOptions } from "./options";
 
 describe("BackOff", () => {
   const mockSuccessResponse = { success: true };
   const mockFailResponse = { success: false };
   let backOffRequest: () => Promise<any>;
-  let backOffOptions: Partial<IBackOffOptions>;
+  let backOffOptions: BackoffOptions;
 
   function initBackOff() {
     return backOff(backOffRequest, backOffOptions);

--- a/src/backoff.ts
+++ b/src/backoff.ts
@@ -1,11 +1,15 @@
-import { IBackOffOptions, getSanitizedOptions } from "./options";
+import {
+  IBackOffOptions,
+  getSanitizedOptions,
+  BackoffOptions
+} from "./options";
 import { DelayFactory } from "./delay/delay.factory";
 
-export { IBackOffOptions };
+export { BackoffOptions, IBackOffOptions };
 
 export async function backOff<T>(
   request: () => Promise<T>,
-  options: Partial<IBackOffOptions> = {}
+  options: BackoffOptions = {}
 ): Promise<T> {
   const sanitizedOptions = getSanitizedOptions(options);
   const backOff = new BackOff(request, sanitizedOptions);

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,7 @@
 export type JitterType = "none" | "full";
 
+export type BackoffOptions = Partial<IBackOffOptions>;
+
 export interface IBackOffOptions {
   delayFirstAttempt: boolean;
   jitter: JitterType;
@@ -20,7 +22,7 @@ const defaultOptions: IBackOffOptions = {
   timeMultiple: 2
 };
 
-export function getSanitizedOptions(options: Partial<IBackOffOptions>) {
+export function getSanitizedOptions(options: BackoffOptions) {
   const sanitized: IBackOffOptions = { ...defaultOptions, ...options };
 
   if (sanitized.numOfAttempts < 1) {


### PR DESCRIPTION
Exporting a `BackoffOptions` interface where all options are optional, and updating the README.md.