### PR TITLE
Stop generating sourceMap in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist/",
-    "sourceMap": true,
+    "sourceMap": false,
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "module": "commonjs",


### PR DESCRIPTION
Stop generating the source map when compiling the project, the `src/` folder isn't published to NPM, so the source map was pointing to non-existing files.

These source maps were causing projects using `exponential-backoff` to break when transpiling the code with webpack.

I created an example showing the error here: https://codesandbox.io/p/sandbox/blissful-orla-9bspqw 

![image](https://user-images.githubusercontent.com/13476437/234564652-8681bf9a-71a2-4e80-95d6-f945b5286531.png)
