### PR TITLE
Fix name of BackoffOptions in readme to match the type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ npm i exponential-backoff
 
 ## Usage
 
-The `backOff<T>` function takes a promise-returning function to retry, and an optional `BackOffOptions` object. It returns a `Promise<T>`.
+The `backOff<T>` function takes a promise-returning function to retry, and an optional `BackoffOptions` object. It returns a `Promise<T>`.
 
 ```ts
 function backOff<T>(
   request: () => Promise<T>,
-  options?: BackOffOptions
+  options?: BackoffOptions
 ): Promise<T>;
 ```
 
@@ -42,7 +42,7 @@ main();
 
 Migrating across major versions? Here are our [breaking changes](https://github.com/coveo/exponential-backoff/tree/master/doc/migration-guide.md).
 
-### `BackOffOptions`
+### `BackoffOptions`
 
 - `delayFirstAttempt?: boolean`
 


### PR DESCRIPTION
The readme displayed code that can't compile because `BackoffOptions` was written as `BackOffOptions` but `BackOffOptions` does not exist.