### PR TITLE
chore: update repo url in the pjson meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coveo/exponential-backoff.git"
+    "url": "git+https://github.com/coveooss/exponential-backoff.git"
   },
   "keywords": [
     "exponential",
@@ -46,9 +46,9 @@
   "author": "Sami Sayegh",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/coveo/exponential-backoff/issues"
+    "url": "https://github.com/coveooss/exponential-backoff/issues"
   },
-  "homepage": "https://github.com/coveo/exponential-backoff#readme",
+  "homepage": "https://github.com/coveooss/exponential-backoff#readme",
   "devDependencies": {
     "@types/jest": "^24.0.18",
     "@types/node": "^10.14.21",


### PR DESCRIPTION
Invalid repo link is causing npm provenance to choke.

```log
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/exponential-backoff - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/coveo/exponential-backoff.git", expected to match "https://github.com/coveooss/exponential-backoff" from provenance
```